### PR TITLE
Emacs warn about end-of-buffer is for interactive use only.

### DIFF
--- a/emacs-init.org
+++ b/emacs-init.org
@@ -2302,7 +2302,7 @@ when switching to the terminal buffer.
     "Go to prompt when switched to ansi-term"
     (when (member major-mode '(term-mode))
       (term-line-mode)
-      (end-of-buffer)
+      (goto-char (point-max))
       (end-of-line)
       (term-char-mode)))
 #+END_SRC


### PR DESCRIPTION
may be this isn't important to commit, sorry if it is
